### PR TITLE
[bids_helper][bids_convert] Fix input folder issue

### DIFF
--- a/brkraw/scripts/brkraw.py
+++ b/brkraw/scripts/brkraw.py
@@ -231,7 +231,7 @@ def main():
                    'task', 'acq', 'ce', 'rec', 'dir', 'run', 'modality', 'Start', 'End']
         df = pd.DataFrame(columns=Headers)
 
-        # if the path directly contains scan files
+        # if the path directly contains scan files for one participant
         if 'subject' in os.listdir(path):
             dNames = ['']
         else:         # old way, when you run against the parent folder (which contains one or more scan folder).
@@ -351,7 +351,14 @@ def main():
                 f.write('## How to cite?\n - https://doi.org/10.5281/zenodo.3818615\n')
 
         print('Inspect input BIDS datasheet...')
-        for dname in sorted(os.listdir(path)):
+
+        # if the path directly contains scan files for one participant
+        if 'subject' in os.listdir(path):
+            dNames = ['']
+        else:         # old way, when you run against the parent folder (which contains one or more scan folder).
+            dNames = sorted(os.listdir(path))
+
+        for dname in dNames:
             dpath = os.path.join(path, dname)
             try:
                 dset = BrukerLoader(dpath)

--- a/brkraw/scripts/brkraw.py
+++ b/brkraw/scripts/brkraw.py
@@ -231,7 +231,13 @@ def main():
                    'task', 'acq', 'ce', 'rec', 'dir', 'run', 'modality', 'Start', 'End']
         df = pd.DataFrame(columns=Headers)
 
-        for dname in sorted(os.listdir(path)):
+        # if the path directly contains scan files
+        if 'subject' in os.listdir(path):
+            dNames = ['']
+        else:         # old way, when you run against the parent folder (which contains one or more scan folder).
+            dNames = sorted(os.listdir(path))
+
+        for dname in dNames:
             dpath = os.path.join(path, dname)
             try:
                 dset = BrukerLoader(dpath)


### PR DESCRIPTION
Fixes #41

Changes proposed in this pull request:
- make bids_helper work on a single scan input folder as well as the parent folder
- make bids_convert work on a single scan input folder as well as the parent folder
- This is not the same issue as #27, however, it shares similarity in terms of single scan folder vs parent folder. This provides a better solution compare to the #27 fixes, where invalid input folder is accepted rather than rejected.

@BrkRaw/Bruker
cc
@gdevenyi 