### PR TITLE
fix RepetitionTime is mutually exclusive with VolumeTiming

### DIFF
--- a/brkraw/lib/loader.py
+++ b/brkraw/lib/loader.py
@@ -554,7 +554,8 @@ class BrukerLoader():
         if ('RepetitionTime' in json_obj.keys()) and ('VolumeTiming' in json_obj.keys()):
             if type(json_obj['RepetitionTime']) == int or type(json_obj['RepetitionTime']) == float:
                 del json_obj['VolumeTiming']
-                msg = "Both 'RepetitionTime' and 'VolumeTiming' exist in your json file, removed 'VolumeTiming' to make it valid for BIDS"
+                msg = "Both 'RepetitionTime' and 'VolumeTiming' exist in your .json file, removed 'VolumeTiming' to make it valid for BIDS.\
+                \n To use VolumeTiming, remove the RepetitionTime item but keep VolumeTiming from the .json file generated from bids_helper."
                 warnings.warn(msg)
 
         with open(os.path.join(dir, '{}.json'.format(filename)), 'w') as f:

--- a/brkraw/lib/loader.py
+++ b/brkraw/lib/loader.py
@@ -546,6 +546,17 @@ class BrukerLoader():
         for k, v in json_obj.items():
             if v is None:
                 json_obj[k] = 'Value was not specified'
+            
+        # RepetitionTime is mutually exclusive with VolumeTiming, here default with RepetitionTime. 
+        # https://bids-specification.readthedocs.io/en/latest/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#required-fields
+        # To use VolumeTiming, remove the RepetitionTime item in .json file generated from bids_helper.
+
+        if ('RepetitionTime' in json_obj.keys()) and ('VolumeTiming' in json_obj.keys()):
+            if type(json_obj['RepetitionTime']) == int or type(json_obj['RepetitionTime']) == float:
+                del json_obj['VolumeTiming']
+                msg = "Both 'RepetitionTime' and 'VolumeTiming' exist in your json file, removed 'VolumeTiming' to make it valid for BIDS"
+                warnings.warn(msg)
+
         with open(os.path.join(dir, '{}.json'.format(filename)), 'w') as f:
             import json
             json.dump(json_obj, f, indent=4)


### PR DESCRIPTION
Fixes #54.
RepetitionTime is mutually exclusive with VolumeTiming.
Here default to use if co-exsit: RepetitionTime (VolumeTiming number array not passing bids validator, [bug](https://github.com/bids-standard/bids-validator/issues/1289)). 

To use VolumeTiming, remove the RepetitionTime item in .json file generated from bids_helper (this should put into documentation somewhere). 

@BrkRaw/Bruker
