### PR TITLE
Fix publish workflow version check and tag matching

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,8 +30,8 @@ jobs:
         if: ${{ github.event_name == 'release' }}
         run: |
           tag="${{ github.ref_name }}"
-          version="$(python - <<'PY'\nfrom pathlib import Path\nimport re\nimport tomllib\n\npyproject = tomllib.loads(Path('pyproject.toml').read_text(encoding='utf-8'))\nversion = None\nif 'project' in pyproject:\n    version = pyproject['project'].get('version')\n\nif not version:\n    version_path = (\n        pyproject.get('tool', {})\n        .get('hatch', {})\n        .get('version', {})\n        .get('path')\n    )\n    if not version_path:\n        raise SystemExit('No version in pyproject.toml and no hatch version path found.')\n    text = Path(version_path).read_text(encoding='utf-8')\n    match = re.search(r\"__version__\\s*=\\s*['\\\"]([^'\\\"]+)['\\\"]\", text)\n    if not match:\n        raise SystemExit(f'No __version__ found in {version_path}')\n    version = match.group(1)\n\nprint(version)\nPY\n)"
-          if [ "v${version}" != "${tag}" ]; then
+          version="$(python -c $'from pathlib import Path\\nimport re\\nimport tomllib\\npyproject = tomllib.loads(Path(\"pyproject.toml\").read_text(encoding=\"utf-8\"))\\nversion = pyproject.get(\"project\", {}).get(\"version\")\\nif not version:\\n    version_path = pyproject.get(\"tool\", {}).get(\"hatch\", {}).get(\"version\", {}).get(\"path\")\\n    if not version_path:\\n        raise SystemExit(\"No version in pyproject.toml and no hatch version path found.\")\\n    text = Path(version_path).read_text(encoding=\"utf-8\")\\n    match = re.search(r\"__version__\\\\s*=\\\\s*[\\\\'\\\\\\\"]([^\\\\'\\\\\\\"]+)[\\\\'\\\\\\\"]\", text)\\n    if not match:\\n        raise SystemExit(f\"No __version__ found in {version_path}\")\\n    version = match.group(1)\\nprint(version)')"
+          if [ "${tag}" != "${version}" ] && [ "${tag}" != "v${version}" ]; then
             echo "Tag ${tag} does not match package version ${version}."
             exit 1
           fi


### PR DESCRIPTION
## Summary

This PR fixes the publish workflow version check by replacing the broken heredoc with a safe one-line Python command and allowing tags with or without the `v` prefix.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor/maintenance
- [ ] Docs update
- [x] CI/CD/workflow

## Checklist

- [ ] I ran tests locally (`pytest`) and they pass
- [ ] I updated/add tests that cover this change
- [ ] I updated documentation where relevant (README, docstrings)
- [x] I considered backward compatibility and breaking changes
- [x] I followed existing code style and conventions

## How to test

```bash
pytest -q
```