### PR TITLE
Fix wheel packaging include to ship source code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,6 @@ sources = ["src"]
 
 [tool.hatch.build.targets.wheel]
 artifacts = ["LICENSE"]
-include = ["src/brkraw/assets/**"]
 
 [tool.pytest.ini_options]
 log_cli = true


### PR DESCRIPTION
- Removes the wheel include filter that was excluding src/brkraw/**
- Restores Hatchling’s default package discovery so the wheel contains code
- Keeps LICENSE artifact unchanged